### PR TITLE
Bump deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5]
+        scala: [2.12.13, 2.13.12]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.5]
+        scala: [2.13.12]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val Scala213 = "2.13.5"
+val Scala213 = "2.13.12"
 
 ThisBuild / crossScalaVersions := Seq("2.12.13", Scala213)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
@@ -11,7 +11,7 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("test")),
 )
 
-val http4sV = "0.22.6"
+val http4sV = "0.22.13"
 val circeV = "0.13.0"
 val logbackClassicV = "1.2.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,8 @@ lazy val `guardrail-sample-http4s` = project.in(file("."))
     // `/src/target/scala-2.13/src_managed/main/example`
     // with folder for server and client which hold their respective generated code.
     guardrailTasks in Compile := List(
-      ScalaServer(file("server.yaml"), pkg="example.server", framework="http4s", tagsBehaviour=tagsAsPackage),
-      ScalaClient(file("server.yaml"), pkg="example.client", framework="http4s", tagsBehaviour=tagsAsPackage),
+      ScalaServer(file("server.yaml"), pkg="example.server", framework="http4s-v0.22", tagsBehaviour=tagsAsPackage),
+      ScalaClient(file("server.yaml"), pkg="example.client", framework="http4s-v0.22", tagsBehaviour=tagsAsPackage),
     )
 
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.9.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.5")
 
 // Add the plugin to the project
-addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "0.71.0")
+addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "0.75.2")


### PR DESCRIPTION
Resolve issues in https://github.com/guardrail-dev/guardrail/issues/1740

- Bumping to a modern enough version of http4s 0.22 to get `Multiparts`
- Bump sbt and guardrail to resolve internal sbt failures
- Explicitly choose the guardrail http4s-v0.22 generator